### PR TITLE
add pagination to pluginproperties, auproperties, contentowners

### DIFF
--- a/src/LOCKSSOMatic/CRUDBundle/Controller/AuPropertiesController.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Controller/AuPropertiesController.php
@@ -46,11 +46,17 @@ class AuPropertiesController extends Controller
     public function indexAction()
     {
         $em = $this->getDoctrine()->getManager();
-
-        $entities = $em->getRepository('LOCKSSOMaticCRUDBundle:AuProperties')->findAll();
+        $dql = 'SELECT p FROM LOCKSSOMaticCRUDBundle:AuProperties p ORDER BY p.id';
+        $query = $em->createQuery($dql);
+        $paginator = $this->get('knp_paginator');
+        $pagination = $paginator->paginate(
+            $query,
+            $this->get('request')->query->get('page', 1),
+            100
+        );
 
         return $this->render('LOCKSSOMaticCRUDBundle:AuProperties:index.html.twig', array(
-            'entities' => $entities,
+            'pagination' => $pagination,
         ));
     }
     /**

--- a/src/LOCKSSOMatic/CRUDBundle/Controller/ContentOwnersController.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Controller/ContentOwnersController.php
@@ -26,11 +26,12 @@
 
 namespace LOCKSSOMatic\CRUDBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-
+use Knp\Component\Pager\Paginator;
 use LOCKSSOMatic\CRUDBundle\Entity\ContentOwners;
 use LOCKSSOMatic\CRUDBundle\Form\ContentOwnersType;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * ContentOwners controller.
@@ -46,11 +47,18 @@ class ContentOwnersController extends Controller
     public function indexAction()
     {
         $em = $this->getDoctrine()->getManager();
-
-        $entities = $em->getRepository('LOCKSSOMaticCRUDBundle:ContentOwners')->findAll();
+        $dql = 'SELECT a FROM LOCKSSOMaticCRUDBundle:ContentOwners a ORDER BY a.id';
+        $query = $em->createQuery($dql);
+        /** @var PaginatorInterface */
+        $paginator = $this->get('knp_paginator');
+        $pagination = $paginator->paginate(
+            $query,
+            $this->get('request')->query->get('page', 1),
+            100
+        );
 
         return $this->render('LOCKSSOMaticCRUDBundle:ContentOwners:index.html.twig', array(
-            'entities' => $entities,
+            'pagination' => $pagination
         ));
     }
     /**
@@ -82,7 +90,7 @@ class ContentOwnersController extends Controller
      *
      * @param ContentOwners $entity The entity
      *
-     * @return \Symfony\Component\Form\Form The form
+     * @return Form The form
      */
     private function createCreateForm(ContentOwners $entity)
     {
@@ -162,7 +170,7 @@ class ContentOwnersController extends Controller
     *
     * @param ContentOwners $entity The entity
     *
-    * @return \Symfony\Component\Form\Form The form
+    * @return Form The form
     */
     private function createEditForm(ContentOwners $entity)
     {
@@ -234,7 +242,7 @@ class ContentOwnersController extends Controller
      *
      * @param mixed $id The entity id
      *
-     * @return \Symfony\Component\Form\Form The form
+     * @return Form The form
      */
     private function createDeleteForm($id)
     {

--- a/src/LOCKSSOMatic/CRUDBundle/Controller/PluginPropertiesController.php
+++ b/src/LOCKSSOMatic/CRUDBundle/Controller/PluginPropertiesController.php
@@ -46,11 +46,17 @@ class PluginPropertiesController extends Controller
     public function indexAction()
     {
         $em = $this->getDoctrine()->getManager();
-
-        $entities = $em->getRepository('LOCKSSOMaticCRUDBundle:PluginProperties')->findAll();
+        $dql = 'SELECT a FROM LOCKSSOMaticCRUDBundle:PluginProperties a ORDER BY a.id';
+        $query = $em->createQuery($dql);
+        $paginator = $this->get('knp_paginator');
+        $pagination = $paginator->paginate(
+            $query,
+            $this->get('request')->query->get('page', 1),
+            100
+        );
 
         return $this->render('LOCKSSOMaticCRUDBundle:PluginProperties:index.html.twig', array(
-            'entities' => $entities,
+            'pagination' => $pagination
         ));
     }
     /**

--- a/src/LOCKSSOMatic/CRUDBundle/Resources/views/AuProperties/index.html.twig
+++ b/src/LOCKSSOMatic/CRUDBundle/Resources/views/AuProperties/index.html.twig
@@ -3,6 +3,7 @@
 {% block body -%}
     <h1>AuProperties list</h1>
 
+    <p>Showing {{ pagination|length }} records of {{ pagination.getTotalItemCount }}.</p>
     <table class="records_list table table-striped table-bordered table-hover">
         <thead>
             <tr>
@@ -13,7 +14,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for entity in entities %}
+        {% for entity in pagination %}
             <tr>
                 <td><a href="{{ path('auproperties_show', { 'id': entity.id }) }}">{{ entity.id }}</a></td>
                 <td>{{ entity.propertyKey }}</td>
@@ -33,11 +34,15 @@
         </tbody>
     </table>
 
-        <ul>
+<div class="navigation">
+    {{ knp_pagination_render(pagination) }}
+</div>        
+
+    <ul>
         <li>
             <a href="{{ path('auproperties_new') }}">
                 Create a new entry
             </a>
         </li>
     </ul>
-    {% endblock %}
+{% endblock %}

--- a/src/LOCKSSOMatic/CRUDBundle/Resources/views/ContentOwners/index.html.twig
+++ b/src/LOCKSSOMatic/CRUDBundle/Resources/views/ContentOwners/index.html.twig
@@ -3,6 +3,7 @@
 {% block body -%}
     <h1>ContentOwners list</h1>
 
+    <p>Showing {{ pagination|length }} records of {{ pagination.getTotalItemCount }}.</p>
     <table class="records_list table table-striped table-bordered table-hover">
         <thead>
             <tr>
@@ -13,7 +14,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for entity in entities %}
+        {% for entity in pagination %}
             <tr>
                 <td><a href="{{ path('contentowners_show', { 'id': entity.id }) }}">{{ entity.id }}</a></td>
                 <td>{{ entity.name }}</td>
@@ -33,7 +34,11 @@
         </tbody>
     </table>
 
-        <ul>
+<div class="navigation">
+    {{ knp_pagination_render(pagination) }}
+</div>        
+
+    <ul>
         <li>
             <a href="{{ path('contentowners_new') }}">
                 Create a new entry

--- a/src/LOCKSSOMatic/CRUDBundle/Resources/views/PluginProperties/index.html.twig
+++ b/src/LOCKSSOMatic/CRUDBundle/Resources/views/PluginProperties/index.html.twig
@@ -3,6 +3,7 @@
 {% block body -%}
     <h1>PluginProperties list</h1>
 
+    <p>Showing {{ pagination|length }} records of {{ pagination.getTotalItemCount }}.</p>
     <table class="records_list table table-striped table-bordered table-hover">
         <thead>
             <tr>
@@ -13,7 +14,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for entity in entities %}
+        {% for entity in pagination %}
             <tr>
                 <td><a href="{{ path('pluginproperties_show', { 'id': entity.id }) }}">{{ entity.id }}</a></td>
                 <td>{{ entity.propertyKey }}</td>
@@ -33,7 +34,12 @@
         </tbody>
     </table>
 
-        <ul>
+        
+<div class="navigation">
+    {{ knp_pagination_render(pagination) }}
+</div>        
+
+    <ul>
         <li>
             <a href="{{ path('pluginproperties_new') }}">
                 Create a new entry


### PR DESCRIPTION
Add pagination to the pluginproperties, auproperties, and contentowners controllers and views. I needed to look at the lists of those entities, but there are too many once the import runs. So paginate them.

All tests pass in Travis. No database or composer update required.
